### PR TITLE
Exclude the node_modules directory from Linter processing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /dist/
+node_modules/


### PR DESCRIPTION
Exclude the node_modules directory that exists in the subdirectory from the target of Linter.
