### PR TITLE
Remove unused dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 * [#123] - Fix CHANGELOG's typo
 
+### Removed Dependencies
+
+#### dependencies
+
+* [#126] - `is-plain-obj`
+
 ### Others
 
 * [#124] - Increasing test execution interval using external API
@@ -13,6 +19,7 @@
 [Unreleased]: https://github.com/sounisi5011/metalsmith-netlify-published-date/compare/v0.3.0...master
 [#123]: https://github.com/sounisi5011/metalsmith-netlify-published-date/pull/123
 [#124]: https://github.com/sounisi5011/metalsmith-netlify-published-date/pull/124
+[#126]: https://github.com/sounisi5011/metalsmith-netlify-published-date/pull/126
 
 ## [0.3.0] (2020-01-04 UTC)
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,7 +11,6 @@
         "deep-freeze-strict": "1.1.1",
         "flat-cache": "2.0.1",
         "import-cwd": "3.0.0",
-        "is-plain-obj": "2.0.0",
         "multimatch": "4.0.0",
         "object-rollback": "1.0.0",
         "parse-link-header": "1.0.1"
@@ -3109,9 +3108,9 @@
           }
         },
         "is-plain-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
         "is-plain-object": {
           "version": "3.0.0",
@@ -3954,11 +3953,6 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
               "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-            },
-            "is-plain-obj": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-              "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
             }
           }
         },
@@ -4410,9 +4404,9 @@
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "picomatch": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-          "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+          "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
         },
         "pidtree": {
           "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3465,6 +3465,12 @@
         "path-is-inside": "^1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
@@ -4419,12 +4425,6 @@
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "dev": true
         }
       }
     },
@@ -4929,9 +4929,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
     "pidtree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3465,11 +3465,6 @@
         "path-is-inside": "^1.0.2"
       }
     },
-    "is-plain-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-      "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
-    },
     "is-plain-object": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "deep-freeze-strict": "1.1.1",
     "flat-cache": "2.0.1",
     "import-cwd": "3.0.0",
-    "is-plain-obj": "2.0.0",
     "multimatch": "4.0.0",
     "object-rollback": "1.0.0",
     "parse-link-header": "1.0.1"


### PR DESCRIPTION
This change should have been done in #116.
By removing the [`src/utils/obj-restore.ts`](https://github.com/sounisi5011/metalsmith-netlify-published-date/blob/74136db05065dbf5e97c89d45d3cdcc498acd37c/src/utils/obj-restore.ts) file, the [is-plain-obj](https://www.npmjs.com/package/is-plain-obj) package is no longer needed.

But I forgot completely 💦